### PR TITLE
make integer division explicit

### DIFF
--- a/RESSPyLab/solution_vis.py
+++ b/RESSPyLab/solution_vis.py
@@ -146,7 +146,7 @@ def plot_function_surfaces(x, x_prct_variation, num_samples, function_values, pl
         f = []
 
         def constr(x2):
-            n_backstresses = int(len(x2) - 6) / 2
+            n_backstresses = int((len(x2) - 6) / 2)
             g = x2[4] * x2[5] - x2[2] * x2[3]
             for ii in range(0, n_backstresses):
                 ck_ind = 6 + 2 * ii

--- a/RESSPyLab/uvc_constraints.py
+++ b/RESSPyLab/uvc_constraints.py
@@ -12,7 +12,7 @@ def g_constraint(x, ep):
     :param float ep: Plastic strain value.
     :return float: Value of g.
     """
-    n_backstresses = int(len(x) - 6) / 2
+    n_backstresses = int((len(x) - 6) / 2)
 
     g = x[4] * x[5] * np.exp(-x[5] * ep) - x[2] * x[3] * np.exp(-x[3] * ep)
     for i in range(0, n_backstresses):
@@ -29,7 +29,7 @@ def g_gradient(x, ep):
     :param float ep: Plastic strain value.
     :return np.array: (n, 1) Gradient of g, n = len(x).
     """
-    n_backstresses = int(len(x) - 6) / 2
+    n_backstresses = int((len(x) - 6) / 2)
 
     grad = np.zeros((len(x), 1))
     grad[2] = -x[3] * np.exp(-x[3] * ep)
@@ -51,7 +51,7 @@ def g_hessian(x, ep):
     :param float ep: Plastic strain value.
     :return np.array: (n, n) Hessian of g, n = len(x).
     """
-    n_backstresses = int(len(x) - 6) / 2
+    n_backstresses = int((len(x) - 6) / 2)
     hess = np.zeros((len(x), len(x)))
 
     # row 2
@@ -136,7 +136,7 @@ def g2_gradient(x, constants, variables):
     :param dict variables: Defines constraint values that depend on x.
     :return float: Value of the constraint in standard form.
     """
-    n_backstresses = int(len(x) - 6) / 2
+    n_backstresses = int((len(x) - 6) / 2)
 
     grad = np.zeros((len(x), 1))
     grad[2] = x[3] ** 2
@@ -159,7 +159,7 @@ def g2_hessian(x, constants, variables):
     :param dict variables: Defines constraint values that depend on x.
     :return float: Value of the constraint in standard form.
     """
-    n_backstresses = int(len(x) - 6) / 2
+    n_backstresses = int((len(x) - 6) / 2)
 
     hess = np.zeros((len(x), len(x)))
     # 2nd row

--- a/RESSPyLab/vc_limited_info_opt.py
+++ b/RESSPyLab/vc_limited_info_opt.py
@@ -93,7 +93,7 @@ def vc_tensile_opt_scipy(x_0, file_list, rho_iso_inf, rho_iso_sup, rho_yield_inf
     g6_sup_constr = opt.NonlinearConstraint(g_6_high.f, constr_lb, constr_ub, jac=g_6_high.gf, hess=g_6_high.hf)
 
     # Make the tuple of constraints
-    n_backstresses = int((len(x_0) - 4) // 2)
+    n_backstresses = int((len(x_0) - 4) / 2)
     if n_backstresses == 2:
         constraints = (g3_inf_constr, g3_sup_constr, g4_inf_constr, g4_sup_constr, g5_inf_constr, g5_sup_constr,
                        g6_inf_constr, g6_sup_constr)
@@ -158,7 +158,7 @@ def vc_tensile_opt_auglag(x_0, file_list, rho_iso_inf, rho_iso_sup, rho_yield_in
                    'rho_gamma_inf': rho_gamma_b_inf, 'rho_gamma_sup': rho_gamma_b_sup,
                    'rho_gamma_12_inf': rho_gamma_12_inf, 'rho_gamma_12_sup': rho_gamma_12_sup}
     # Set-up constraints
-    n_backstresses = int((len(x_0) - 4) // 2)
+    n_backstresses = int((len(x_0) - 4) / 2)
     if n_backstresses == 2:
         constraint_dict = {'constants': g_constants, 'variables': {},
                            'functions': [g3_vco_lower, g3_vco_upper, g4_vco_lower, g4_vco_upper,
@@ -237,7 +237,7 @@ def vc_tensile_opt_linesearch(x_0, file_list, rho_iso_inf, rho_iso_sup, rho_yiel
                    'rho_gamma_inf': rho_gamma_b_inf, 'rho_gamma_sup': rho_gamma_b_sup,
                    'rho_gamma_12_inf': rho_gamma_12_inf, 'rho_gamma_12_sup': rho_gamma_12_sup}
     # Set-up constraints
-    n_backstresses = int((len(x_0) - 4) // 2)
+    n_backstresses = int((len(x_0) - 4) / 2)
     if n_backstresses == 2:
         constraint_dict = {'constants': g_constants, 'variables': {},
                            'functions': [g3_vco_lower, g3_vco_upper, g4_vco_lower, g4_vco_upper,
@@ -300,7 +300,7 @@ def make_feasible(x_0, c):
         - x_0 should follow: x0 = [200000, 355, 1, 1, 1, 1] for one backstress
         - x_0 should follow: x0 = [200000, 355, 1, 1, 1, rho_gamma_12_inf, 1, 1] for two backstresses
     """
-    n_backstresses = int((len(x_0) - 4) // 2)
+    n_backstresses = int((len(x_0) - 4) / 2)
     # Get the average of the bounds
     rho_yield_avg = 0.5 * (c['rho_yield_inf'] + c['rho_yield_sup'])
     rho_iso_avg = 0.5 * (c['rho_iso_inf'] + c['rho_iso_sup'])
@@ -320,7 +320,7 @@ def make_feasible(x_0, c):
 def vc_constraint_check(x_opt, rho_iso_inf, rho_iso_sup, rho_yield_inf, rho_yield_sup, rho_gamma_b_inf,
                         rho_gamma_b_sup):
     """ Checks if each of g_3, g_4, and g_5 were satisfied. """
-    n_backstresses = int((len(x_opt) - 4) // 2)
+    n_backstresses = int((len(x_opt) - 4) / 2)
     sum_c_gamma = 0.
     for i in range(n_backstresses):
         sum_c_gamma += x_opt[4 + 2 * i] / x_opt[5 + 2 * i]


### PR DESCRIPTION
In python 3, j/k always returns a float. Using the result in the range() function results in an error.
Integer division is performed using j // k, or more explicitly
int(j/k).

The explicit syntax is already used in most files.

This commit replaces the first syntax which doesn't work in python 3 with the explicit division, in the following files:
	modified:   RESSPyLab/solution_vis.py
	modified:   RESSPyLab/uvc_constraints.py
	modified:   RESSPyLab/vc_limited_info_opt.py